### PR TITLE
Use SSH for lion-bsp instead.

### DIFF
--- a/lion-ems-mpu-dev-board.xml
+++ b/lion-ems-mpu-dev-board.xml
@@ -12,7 +12,7 @@
   <remote fetch="https://github.com/openembedded" name="oe"/>
   <remote fetch="https://git.yoctoproject.org/git" name="yocto"/>
   <remote fetch="https://github.com/nxp-imx-support" name="imx-support"/>
-  <remote fetch="https://github.com/PoweredByLionEnergy" name="lion-bsp"/>
+  <remote fetch="ssh://git@github.com/PoweredByLionEnergy" name="lion-bsp"/>
 
   <project name="fsl-community-bsp-base" path="sources/base" remote="community" revision="60f79f7af60537146298560079ae603260f0bd14" upstream="kirkstone">
     <linkfile dest="README" src="README"/>


### PR DESCRIPTION
I don't know if this is a good idea, but I generally prefer to use SSH keys to login to the git.